### PR TITLE
Fix Multilines function signature

### DIFF
--- a/Symfony2/ruleset.xml
+++ b/Symfony2/ruleset.xml
@@ -50,6 +50,9 @@
     <rule ref="Zend">
         <!-- but exclude their code analyzer -->
         <exclude name="Zend.Debug.CodeAnalyzer"/>
+        
+        <!-- exclude their function signature standard conflicting function multilines signature -->
+        <exclude name="Generic.Functions.OpeningFunctionBraceBsdAllman"/>
 
         <!-- covered by Squiz ControlSignature, which enforces try/catch as well -->
         <exclude name="PEAR.ControlStructures.ControlSignature"/>


### PR DESCRIPTION
See http://www.php-fig.org/psr/psr-2/#4-4-method-arguments 

Argument lists MAY be split across multiple lines, where each subsequent line is indented once. When doing so, the first item in the list MUST be on the next line, and there MUST be only one argument per line.

When the argument list is split across multiple lines, the closing parenthesis and opening brace MUST be placed together on their own line with one space between them.
